### PR TITLE
Use correct context for event handlers

### DIFF
--- a/assets/utils.js
+++ b/assets/utils.js
@@ -123,7 +123,7 @@ function hijackComponentEvents(original) {
           event: target,
           template: name
         };
-        handler.apply(self, args);
+        handler.apply(this, args);
       };
     }
 


### PR DESCRIPTION
Previously it was running event handlers under Template context
