### PR TITLE
Avoid _bound of undefined using trackjs and ionic

### DIFF
--- a/assets/zone.js
+++ b/assets/zone.js
@@ -944,7 +944,7 @@ function patchEventTargetMethods(obj, thing) {
 
   var removeDelegate = obj.removeEventListener;
   obj.removeEventListener = function (eventName, fn) {
-    if(arguments[1]._bound && arguments[1]._bound[eventName]) {
+    if(arguments[1] && arguments[1]._bound && arguments[1]._bound[eventName]) {
       var _bound = arguments[1]._bound;
       arguments[1] = _bound[eventName];
       delete _bound[eventName];


### PR DESCRIPTION
I need this changement to avoid the error _bound of undefined in meteor / ionic / angular app using track.js
